### PR TITLE
[BUGFIX] Prevent usage of deprecated and remove method DocumentTempla…

### DIFF
--- a/Classes/View/AdministrationModuleFunction.php
+++ b/Classes/View/AdministrationModuleFunction.php
@@ -1433,7 +1433,7 @@ class AdministrationModuleFunction extends \TYPO3\CMS\Backend\Module\AbstractFun
      */
     public function redirectView()
     {
-        $output = $this->pObj->doc->spacer(12);
+        $output = '<div style="padding-top: 12px;"></div>';
         $output .= $this->processRedirectActions();
 
         list($sortingParameter, $sortingDirection) = $this->getRedirectViewSortingParameters();


### PR DESCRIPTION
…te->spacer()

This function was deprecated in TYPO3 CMS 7 and removed in TYPO3 CMS 8.

See: https://review.typo3.org/44382/

Resolves: #16 