### PR TITLE
[TASK] Downgrade Travis CI dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: precise
+
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
As the framework still needs support for PHP 5.3, the old distribution
has to be enabled.