### PR TITLE
[TASK] PHP CS Fixer: Allow risky rules

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -7,6 +7,7 @@ This file is part of the TYPO3 extension hellurl.
 EOF;
 
 return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
     ->setRules(array(
         '@PSR2' => true,
         'array_syntax' => array(


### PR DESCRIPTION
This patch enables risky rules for PHP CS Fixer as some configured
rules need the risky flag enabled.