### PR TITLE
[TASK] Update composer.json license definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "typo3-cms-extension",
     "description": "HellUrl: speaking paths for TYPO3",
     "homepage": "https://github.com/Nimut/TYPO3-hellurl",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=5.3.7 <7.2",
         "typo3/cms-core": "^6.2.6 || ^7.6 || ^8.7"


### PR DESCRIPTION
Composer license definition GPL-2.0+ has been deprecated and has to be
replaced with GPL-2.0-or-later.